### PR TITLE
ExceptionHandler 구현 (HTTP 상태코드 단위 -> 도메인 단위)

### DIFF
--- a/src/main/java/com/fastcampus/jober/global/constant/ErrorCode.java
+++ b/src/main/java/com/fastcampus/jober/global/constant/ErrorCode.java
@@ -1,28 +1,35 @@
 package com.fastcampus.jober.global.constant;
 
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
 public enum ErrorCode {
 
-    INVALID_REQUEST("잘못된 요청입니다"),
-    INVALID_ID("유효하지 않은 id값입니다"),
-    INVALID_AUTHENTICATION("인증되지 않았습니다"),
-    INVALID_ACCESS("잘못된 접근입니다"),
-    INVALID_USER("권한이 없습니다"),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
+    INVALID_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 id값입니다"),
+    INVALID_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증되지 않았습니다"),
+    INVALID_ACCESS(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 접근입니다"),
+    INVALID_USER(HttpStatus.FORBIDDEN, "권한이 없습니다"),
+    EMPTY_ID(HttpStatus.BAD_REQUEST, "아이디를 입력해주세요"),
+    EMPTY_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호를 입력해주세요"),
+    EXISTING_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다"),
+    CHECK_ID_PASSWORD(HttpStatus.BAD_REQUEST, "아이디와 비밀번호를 확인해주세요"),
+    CHECK_ID(HttpStatus.BAD_REQUEST, "아이디를 확인해주세요"),
+    CHECK_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호를 확인해주세요");
 
-    EMPTY_ID("아이디를 입력해주세요"),
-    EMPTY_PASSWORD("비밀번호를 입력해주세요"),
-
-    EXISTING_EMAIL("이미 존재하는 이메일입니다"),
-    CHECK_ID_PASSWORD("아이디와 비밀번호를 확인해주세요"),
-    CHECK_ID("아이디를 확인해주세요"),
-    CHECK_PASSWORD("비밀번호를 확인해주세요");
-
+    private final HttpStatus httpStatus;
     private final String message;
-
-    ErrorCode(String message) {
-        this.message = message;
-    }
 
     public String getMessage() {
         return message;
+    }
+
+    public int getStatusCode() {
+        return httpStatus.value();
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
     }
 }

--- a/src/main/java/com/fastcampus/jober/global/error/advice/MyExceptionAdvice.java
+++ b/src/main/java/com/fastcampus/jober/global/error/advice/MyExceptionAdvice.java
@@ -1,9 +1,12 @@
 package com.fastcampus.jober.global.error.advice;
 
+import com.fastcampus.jober.global.error.exception.DomainException;
 import com.fastcampus.jober.global.error.exception.Exception401;
 import com.fastcampus.jober.global.error.exception.Exception403;
 import com.fastcampus.jober.global.error.exception.Exception500;
 import com.fastcampus.jober.global.error.exception.ExceptionValid;
+import com.fastcampus.jober.global.util.ApiUtil;
+import com.fastcampus.jober.global.util.ApiUtil.ApiResponse;
 import com.fastcampus.jober.global.utils.api.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +37,22 @@ public class MyExceptionAdvice {
         return new ResponseEntity<>(e.body(), e.status());
     }
 
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<?> globalExceptionHandler(DomainException e) {
+        ApiResponse response = ApiUtil.result(e.getCode(), e.getMessage(), null);
+
+        return new ResponseEntity<>(response, e.getHttpStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> methodValidException(MethodArgumentNotValidException e) {
+        ExceptionValid ev = new ExceptionValid(
+            e.getBindingResult().getFieldError().getCode(),
+            e.getBindingResult().getFieldError().getDefaultMessage()
+        );
+        return new ResponseEntity<>(ev.body(), ev.status());
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> unknownServerError(Exception e) {
 
@@ -44,14 +63,5 @@ public class MyExceptionAdvice {
             );
         log.error(e.getMessage(), e);
         return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<?> methodValidException(MethodArgumentNotValidException e) {
-        ExceptionValid ev = new ExceptionValid(
-            e.getBindingResult().getFieldError().getCode(),
-            e.getBindingResult().getFieldError().getDefaultMessage()
-        );
-        return new ResponseEntity<>(ev.body(), ev.status());
     }
 }

--- a/src/main/java/com/fastcampus/jober/global/error/exception/DomainException.java
+++ b/src/main/java/com/fastcampus/jober/global/error/exception/DomainException.java
@@ -1,0 +1,23 @@
+package com.fastcampus.jober.global.error.exception;
+
+import com.fastcampus.jober.global.constant.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DomainException extends RuntimeException {
+
+    private HttpStatus httpStatus;
+    private int code;
+    private String message;
+
+    public DomainException(ErrorCode errorCode) {
+        this.httpStatus = errorCode.getHttpStatus();
+        this.code = errorCode.getStatusCode();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/fastcampus/jober/global/error/exception/MemberException.java
+++ b/src/main/java/com/fastcampus/jober/global/error/exception/MemberException.java
@@ -1,0 +1,12 @@
+package com.fastcampus.jober.global.error.exception;
+
+import com.fastcampus.jober.global.constant.ErrorCode;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class MemberException extends DomainException {
+
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/fastcampus/jober/global/error/exception/TemplateException.java
+++ b/src/main/java/com/fastcampus/jober/global/error/exception/TemplateException.java
@@ -1,0 +1,12 @@
+package com.fastcampus.jober.global.error.exception;
+
+import com.fastcampus.jober.global.constant.ErrorCode;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class TemplateException extends DomainException {
+
+    public TemplateException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/fastcampus/jober/global/error/exception/TokenException.java
+++ b/src/main/java/com/fastcampus/jober/global/error/exception/TokenException.java
@@ -1,0 +1,12 @@
+package com.fastcampus.jober.global.error.exception;
+
+import com.fastcampus.jober.global.constant.ErrorCode;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class TokenException extends DomainException {
+
+    public TokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/fastcampus/jober/global/util/ApiUtil.java
+++ b/src/main/java/com/fastcampus/jober/global/util/ApiUtil.java
@@ -1,19 +1,20 @@
 package com.fastcampus.jober.global.util;
 
+import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 public class ApiUtil {
 
-    public static <T> Response<T> result(int code, String message, T data) {
-        return new Response<>(code, message, data);
+    public static <T> ApiResponse<T> result(int code, String message, @Nullable T data) {
+        return new ApiResponse<>(code, message, data);
     }
 
     @Getter
     @Setter
     @AllArgsConstructor
-    public static class Response<T> {
+    public static class ApiResponse<T> {
 
         private final int code;
         private final String message;


### PR DESCRIPTION
- DomainException이라는 RuntimeException 상속받는 클래스 생성
- 해당 DomainException을 상속받는 각 도메인별 Exception 생성 (예 : TemplateException)
- MyExceptionAdvice에 DomainException Handler 생성