### PR TITLE
공유스페이스 권한 API 구현 및 수정

### DIFF
--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/controller/SpaceWallPermissionController.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/controller/SpaceWallPermissionController.java
@@ -1,0 +1,29 @@
+package com.fastcampus.jober.domain.spacewallpermission.controller;
+
+import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionRequestDto;
+import com.fastcampus.jober.domain.spacewallpermission.service.SpaceWallPermissionService;
+import com.fastcampus.jober.global.utils.api.dto.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/spaces")
+@RequiredArgsConstructor
+public class SpaceWallPermissionController {
+
+    private final SpaceWallPermissionService spaceWallPermissionService;
+
+    @PutMapping("/{id}/authority")
+    public ResponseEntity<ResponseDTO<String>> updatePermission(@PathVariable Long id, @RequestBody SpaceWallPermissionRequestDto requestDto) {
+        spaceWallPermissionService.updatePermission(id, requestDto);
+        return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "권한을 수정하였습니다.", null));
+    }
+
+    @PutMapping("/{id}/move")
+    public ResponseEntity<ResponseDTO<String>> moveSpaceWallPermission(@PathVariable Long id, @RequestBody SpaceWallPermissionRequestDto requestDto) {
+        spaceWallPermissionService.moveSpaceWallPermission(id, requestDto.getParentId());
+        return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "공유페이지의 위치를 수정하였습니다.", null));
+    }
+}

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/domain/SpaceWallPermission.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/domain/SpaceWallPermission.java
@@ -2,6 +2,7 @@ package com.fastcampus.jober.domain.spacewallpermission.domain;
 
 import com.fastcampus.jober.domain.member.domain.Member;
 import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
+import com.fastcampus.jober.domain.spacewallmember.domain.SpaceWallMember;
 import com.fastcampus.jober.global.constant.Auths;
 import com.fastcampus.jober.global.constant.Type;
 import jakarta.persistence.*;
@@ -28,6 +29,12 @@ public class SpaceWallPermission {
     @OnDelete(action = OnDeleteAction.CASCADE)
     @PrimaryKeyJoinColumn
     private SpaceWall spaceWall;
+
+    //    @JsonIgnore
+    @OneToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "space_wall_member_id")
+    private SpaceWallMember spaceWallMember;
 
     //    @JsonIgnore
     @OneToOne

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/domain/SpaceWallPermission.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/domain/SpaceWallPermission.java
@@ -1,23 +1,21 @@
 package com.fastcampus.jober.domain.spacewallpermission.domain;
 
-import com.fastcampus.jober.domain.spacewallmember.domain.SpaceWallMember;
+import com.fastcampus.jober.domain.member.domain.Member;
+import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
 import com.fastcampus.jober.global.constant.Auths;
 import com.fastcampus.jober.global.constant.Type;
 import jakarta.persistence.*;
-import lombok.*;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
-import java.time.LocalDateTime;
-
 @Entity
-@Table(name = "space_wall_permission")
 @Data
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-@Builder
 public class SpaceWallPermission {
 
     @Id
@@ -28,8 +26,14 @@ public class SpaceWallPermission {
     //    @JsonIgnore
     @OneToOne
     @OnDelete(action = OnDeleteAction.CASCADE)
-    @JoinColumn(name = "space_wall_member_id")
-    private SpaceWallMember spaceWallMember;
+    @PrimaryKeyJoinColumn
+    private SpaceWall spaceWall;
+
+    //    @JsonIgnore
+    @OneToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @PrimaryKeyJoinColumn
+    private Member member;
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
@@ -38,6 +42,9 @@ public class SpaceWallPermission {
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private Auths auths; // READ / EDIT / DELETE
+
+    @Column
+    private Long parentId; // 상위 페이지 ID
 
     @Column(nullable = false)
     @CreatedDate
@@ -52,7 +59,10 @@ public class SpaceWallPermission {
         this.createdAt = LocalDateTime.now();
     }
 
-    protected void onUpdate() { // 권한 수정 시 호출
-        this.updatedAt = LocalDateTime.now();
+    @PreUpdate
+    protected void onUpdate() { this.updatedAt = LocalDateTime.now();  }
+
+    public void setAuths(Auths auths) {
+        this.auths = auths;
     }
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionRequestDto.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionRequestDto.java
@@ -1,0 +1,18 @@
+package com.fastcampus.jober.domain.spacewallpermission.dto;
+
+import com.fastcampus.jober.global.constant.Auths;
+import com.fastcampus.jober.global.constant.Type;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpaceWallPermissionRequestDto {
+    private Long spaceWallId;  // 공유 스페이스 ID
+    private Long memberId;     // 회원 ID
+    private Type type;         // WHITE / BLACK
+    private Auths auths;       // READ / EDIT / DELETE
+    private Long parentId;     // 상위 페이지 ID
+}

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionResponseDto.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionResponseDto.java
@@ -1,0 +1,35 @@
+package com.fastcampus.jober.domain.spacewallpermission.dto;
+
+import com.fastcampus.jober.domain.spacewallpermission.domain.SpaceWallPermission;
+import com.fastcampus.jober.global.constant.Auths;
+import com.fastcampus.jober.global.constant.Type;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpaceWallPermissionResponseDto {
+    private Long id;
+    private Long spaceWallId;  // 공유 스페이스 ID
+    private Long memberId;     // 회원 ID
+    private Type type;         // WHITE / BLACK
+    private Auths auths;       // READ / EDIT / DELETE
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Long parentId;     // 상위 페이지 ID
+
+    public SpaceWallPermissionResponseDto(SpaceWallPermission spaceWallPermission) {
+        this.id = spaceWallPermission.getId();
+        this.spaceWallId = spaceWallPermission.getSpaceWall().getId();
+        this.memberId = spaceWallPermission.getMember().getId();
+        this.type = spaceWallPermission.getType();
+        this.auths = spaceWallPermission.getAuths();
+        this.createdAt = spaceWallPermission.getCreatedAt();
+        this.updatedAt = spaceWallPermission.getUpdatedAt();
+        this.parentId = spaceWallPermission.getParentId();
+    }
+}

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/repository/SpaceWallPermissionRepository.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/repository/SpaceWallPermissionRepository.java
@@ -1,5 +1,6 @@
 package com.fastcampus.jober.domain.spacewallpermission.repository;
 
+import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
 import com.fastcampus.jober.domain.spacewallpermission.domain.SpaceWallPermission;
 import com.fastcampus.jober.global.constant.Auths;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 public interface SpaceWallPermissionRepository extends JpaRepository<SpaceWallPermission, Long> {
 
@@ -25,4 +28,6 @@ public interface SpaceWallPermissionRepository extends JpaRepository<SpaceWallPe
 
     @Query("SELECT swp.auths FROM SpaceWallPermission swp WHERE swp.spaceWallMember.id = :spaceWallMemberId")
     Auths selectAuths(@Param("spaceWallMemberId") Long spaceWallMemberId);
+
+    Optional<SpaceWallPermission> findBySpaceWall(SpaceWall spaceWall);
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/service/SpaceWallPermissionService.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/service/SpaceWallPermissionService.java
@@ -2,22 +2,62 @@ package com.fastcampus.jober.domain.spacewallpermission.service;
 
 import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
 import com.fastcampus.jober.domain.spacewallpermission.domain.SpaceWallPermission;
+import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionRequestDto;
+import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionResponseDto;
+import com.fastcampus.jober.domain.spacewallpermission.repository.SpaceWallPermissionRepository;
 import com.fastcampus.jober.global.constant.Auths;
+import com.fastcampus.jober.global.constant.Type;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class SpaceWallPermissionService {
 
-    public SpaceWallPermissionService() {
+    private final SpaceWallPermissionRepository spaceWallPermissionRepository;
 
+    @Transactional
+    public SpaceWallPermissionResponseDto updatePermission(Long id, SpaceWallPermissionRequestDto requestDto) {
+        SpaceWallPermission spaceWallPermission = spaceWallPermissionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 공유페이스 권한 ID입니다."));
+
+        spaceWallPermission.setAuths(requestDto.getAuths());
+        spaceWallPermission.setType(requestDto.getType());
+
+        return new SpaceWallPermissionResponseDto(spaceWallPermission);
     }
 
-    public void assignPermissionToSpaceWall(Auths auth, SpaceWall spaceWall) {
+    @Transactional
+    public SpaceWallPermissionResponseDto moveSpaceWallPermission(Long id, Long parentId) {
+        SpaceWallPermission spaceWallPermission = spaceWallPermissionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 공유페이스 권한 ID입니다."));
 
+        // 권한 검사
+        if (parentId != null) {
+            SpaceWallPermission parentPermission = spaceWallPermissionRepository.findById(parentId)
+                    .orElseThrow(() -> new IllegalArgumentException("잘못된 상위 공유페이스 권한 ID입니다."));
+
+            if (parentPermission.getType() == Type.BLACK) {
+                throw new IllegalArgumentException("목록 페이지로 이동할 수 없습니다..");
+            }
+        }
+
+        spaceWallPermission.setParentId(parentId);
+
+        return new SpaceWallPermissionResponseDto(spaceWallPermission);
+    }
+
+    @Transactional
+    public void assignPermissionToSpaceWall(Auths auth, SpaceWall spaceWall) {
+        SpaceWallPermission permission = new SpaceWallPermission();
+        permission.setSpaceWall(spaceWall);
+        permission.setAuths(auth);
+        spaceWallPermissionRepository.save(permission);
     }
 
     public SpaceWallPermission getPermissionForSpaceWall(SpaceWall spaceWall) {
-        return null;
+        return spaceWallPermissionRepository.findBySpaceWall(spaceWall)
+                .orElseThrow(() -> new IllegalArgumentException("해당 공유 스페이스에 대한 권한 정보를 찾을 수 없습니다."));
     }
-
 }


### PR DESCRIPTION
[#4 ]

1. 공유스페이스 권한 API - updatePermission: 특정 ID를 가진 공유 스페이스 권한의 타입 및 권한 수준을 수정
2. 공유스페이스 이동 API - moveSpaceWallPermission: 공유 스페이스 권한의 상위 페이지 ID를 변경하여 위치를 이동
3. assignPermissionToSpaceWall: 특정 공유 스페이스에 권한을 할당
4. getPermissionForSpaceWall: 특정 공유 스페이스의 권한 정보를 조회
5. 현재 기능만 구현한 상태라서 일단 참고을 위해 pr 이후에 예외처리 로직 변경 수정을 해서 다시 pr 하겠습니다.