### PR TITLE
공유스페이스 권한 API 수정

### DIFF
--- a/src/main/java/com/fastcampus/jober/domain/spacewall/domain/SpaceWall.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/domain/SpaceWall.java
@@ -66,5 +66,8 @@ public class SpaceWall extends BaseTimeEntity {
         if (updatedSpaceWall.getShareUrl() != null) this.shareUrl = updatedSpaceWall.getShareUrl();
         if (updatedSpaceWall.getShareExpiredAt() != null) this.shareExpiredAt = updatedSpaceWall.getShareExpiredAt();
     }
+    public void setSequence(int sequence) {
+        this.sequence = sequence;
+    }
 
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/domain/SpaceWall.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/domain/SpaceWall.java
@@ -57,7 +57,6 @@ public class SpaceWall extends BaseTimeEntity {
     }
 
     public void update(SpaceWall updatedSpaceWall) {
-//        if (updatedSpaceWall.getLayout() != null) this.layout = updatedSpaceWall.getLayout();
         if (updatedSpaceWall.getUrl() != null) this.url = updatedSpaceWall.getUrl();
         if (updatedSpaceWall.getTitle() != null) this.title = updatedSpaceWall.getTitle();
         if (updatedSpaceWall.getDescription() != null) this.description = updatedSpaceWall.getDescription();

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallRequest.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallRequest.java
@@ -27,17 +27,12 @@ public class SpaceWallRequest {
         private Integer sequence;
 
         public SpaceWall toEntity() {
-//            SpaceWallLayout layout = SpaceWallLayout.builder().id(layoutId).build();
             Member member = Member.builder().id(createMemberId).build();
-//            Workspace workspace = Workspace.builder().id(workspaceId).build();
 
             LocalDateTime shareExpiration = (shareExpiredAt != null) ?
                     LocalDateTime.ofInstant(shareExpiredAt.toInstant(), ZoneId.systemDefault()) : null;
 
             return SpaceWall.builder()
-//                    .layout(layout)
-//                    .createMember(member)
-//                    .workspace(workspace)
                     .url(url)
                     .title(title)
                     .description(description)
@@ -65,13 +60,11 @@ public class SpaceWallRequest {
         private Date shareExpiredAt;
 
         public SpaceWall toEntity() {
-//            SpaceWallLayout layout = SpaceWallLayout.builder().id(layoutId).build();
 
             LocalDateTime shareExpiration = (shareExpiredAt != null) ?
                     LocalDateTime.ofInstant(shareExpiredAt.toInstant(), ZoneId.systemDefault()) : null;
 
             return SpaceWall.builder()
-//                    .layout(layout)
                     .url(url)
                     .title(title)
                     .description(description)

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallResponse.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallResponse.java
@@ -32,9 +32,6 @@ public class SpaceWallResponse {
 
         public ResponseDto(SpaceWall spaceWall) {
             this.id = spaceWall.getId();
-//            this.layout_id = spaceWall.getLayout() != null ? spaceWall.getLayout().getId() : null;
-//            this.create_member_id = spaceWall.getCreateMember() != null ? spaceWall.getCreateMember().getId() : null;
-//            this.workspace_id = spaceWall.getWorkspace() != null ? spaceWall.getWorkspace().getId() : null;
             this.url = spaceWall.getUrl();
             this.title = spaceWall.getTitle();
             this.description = spaceWall.getDescription();
@@ -49,15 +46,10 @@ public class SpaceWallResponse {
         }
 
         public SpaceWall toEntity() {
-//            SpaceWallLayout layout = SpaceWallLayout.builder().id(layout_id).build();
             Member member = Member.builder().id(create_member_id).build();
-//            Workspace workspace = Workspace.builder().id(workspace_id).build();
 
             return SpaceWall.builder()
                     .id(id)
-//                    .layout(layout)
-//                    .createMember(member)
-//                    .workspace(workspace)
                     .url(url)
                     .title(title)
                     .description(description)

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/repository/SpaceWallRepository.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/repository/SpaceWallRepository.java
@@ -4,9 +4,10 @@ import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface SpaceWallRepository extends JpaRepository<SpaceWall, Long> {
-
+    List<SpaceWall> findBySequenceBetween(int start, int end);
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/controller/SpaceWallPermissionController.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/controller/SpaceWallPermissionController.java
@@ -1,6 +1,7 @@
 package com.fastcampus.jober.domain.spacewallpermission.controller;
 
 import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionRequest;
+import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionResponse;
 import com.fastcampus.jober.domain.spacewallpermission.service.SpaceWallPermissionService;
 import com.fastcampus.jober.global.utils.api.dto.ResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +17,14 @@ public class SpaceWallPermissionController {
     private final SpaceWallPermissionService spaceWallPermissionService;
 
     @PutMapping("/{id}/authority")
-    public ResponseEntity<ResponseDTO<String>> updatePermission(@PathVariable Long id, @RequestBody SpaceWallPermissionRequest requestDto) {
-        spaceWallPermissionService.updatePermission(id, requestDto);
-        return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "권한을 수정하였습니다.", null));
+    public ResponseEntity<ResponseDTO<SpaceWallPermissionResponse>> updatePermission(@PathVariable Long id, @RequestBody SpaceWallPermissionRequest requestDto) {
+        SpaceWallPermissionResponse response = spaceWallPermissionService.updatePermission(id, requestDto);
+        return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "권한을 수정하였습니다.", response));
     }
 
     @PutMapping("/{id}/move")
-    public ResponseEntity<ResponseDTO<String>> moveSpaceWallPermission(@PathVariable Long id, @RequestBody SpaceWallPermissionRequest requestDto) {
-        spaceWallPermissionService.moveSpaceWallPermission(id, requestDto.getParentId());
-        return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "공유페이지의 위치를 수정하였습니다.", null));
+    public ResponseEntity<ResponseDTO<SpaceWallPermissionResponse>> moveSpaceWallPermission(@PathVariable Long id, @RequestBody SpaceWallPermissionRequest requestDto) {
+        SpaceWallPermissionResponse response = spaceWallPermissionService.moveSpaceWallPermission(id, requestDto.getTargetSequence());
+        return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "공유페이지의 위치를 수정하였습니다.", response));
     }
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/domain/SpaceWallPermission.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/domain/SpaceWallPermission.java
@@ -13,7 +13,7 @@ import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Data
-@EqualsAndHashCode(callSuper=false)
+@EqualsAndHashCode(callSuper = false)
 public class SpaceWallPermission extends BaseTimeEntity {
 
     @Id
@@ -22,23 +22,11 @@ public class SpaceWallPermission extends BaseTimeEntity {
     private Long id;
 
     //    @JsonIgnore
-//    @OneToOne
-//    @OnDelete(action = OnDeleteAction.CASCADE)
-//    @PrimaryKeyJoinColumn
-//    private SpaceWall spaceWall;
-
-    //    @JsonIgnore
     @OneToOne
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "space_wall_member_id")
     @PrimaryKeyJoinColumn
     private SpaceWallMember spaceWallMember;
-
-    //    @JsonIgnore
-//    @OneToOne
-//    @OnDelete(action = OnDeleteAction.CASCADE)
-//    @PrimaryKeyJoinColumn
-//    private Member member;
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/domain/SpaceWallPermission.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/domain/SpaceWallPermission.java
@@ -33,7 +33,7 @@ public class SpaceWallPermission extends BaseTimeEntity {
     private Auths auths = Auths.VIEWER; // READ를 기본값으로 설정
 
     @Column
-    private Long parentId; // 상위 페이지 ID
+    private Long parentId;
 
     public void setAuths(Auths auths) {
         this.auths = auths;

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionRequest.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionRequest.java
@@ -12,7 +12,6 @@ import lombok.*;
 public class SpaceWallPermissionRequest {
     private Long spaceWallId;  // 공유 스페이스 ID
     private Long memberId;     // 회원 ID
-    private Type type;         // WHITE / BLACK
     private Auths auths;       // READ / EDIT / DELETE
     private Long parentId;     // 상위 페이지 ID
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionRequest.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionRequest.java
@@ -13,5 +13,5 @@ public class SpaceWallPermissionRequest {
     private Long spaceWallId;  // 공유 스페이스 ID
     private Long memberId;     // 회원 ID
     private Auths auths;       // READ / EDIT / DELETE
-    private Long parentId;     // 상위 페이지 ID
+    private Long targetSequence;    // 상위 페이지 ID
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionResponse.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionResponse.java
@@ -13,8 +13,6 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class SpaceWallPermissionResponse {
     private Long id;
-//    private Long spaceWallId;  // 공유 스페이스 ID
-//    private Long memberId;     // 회원 ID
     private Auths auths;       // READ / EDIT / DELETE
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -22,8 +20,6 @@ public class SpaceWallPermissionResponse {
 
     public SpaceWallPermissionResponse(SpaceWallPermission spaceWallPermission) {
         this.id = spaceWallPermission.getId();
-//        this.spaceWallId = spaceWallPermission.getSpaceWall().getId();
-//        this.memberId = spaceWallPermission.getMember().getId();
         this.auths = spaceWallPermission.getAuths();
         this.createdAt = spaceWallPermission.getCreatedAt();
         this.updatedAt = spaceWallPermission.getUpdatedAt();

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/service/SpaceWallPermissionService.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/service/SpaceWallPermissionService.java
@@ -1,20 +1,25 @@
 package com.fastcampus.jober.domain.spacewallpermission.service;
 
 import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
+import com.fastcampus.jober.domain.spacewall.repository.SpaceWallRepository;
 import com.fastcampus.jober.domain.spacewallpermission.domain.SpaceWallPermission;
 import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionRequest;
 import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionResponse;
 import com.fastcampus.jober.domain.spacewallpermission.repository.SpaceWallPermissionRepository;
 import com.fastcampus.jober.global.constant.Auths;
+import com.fastcampus.jober.global.error.exception.InvalidTargetSequenceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class SpaceWallPermissionService {
 
     private final SpaceWallPermissionRepository spaceWallPermissionRepository;
+    private final SpaceWallRepository spaceWallRepository;
 
     @Transactional
     public SpaceWallPermissionResponse updatePermission(Long id, SpaceWallPermissionRequest requestDto) {
@@ -28,23 +33,43 @@ public class SpaceWallPermissionService {
     }
 
     @Transactional
-    public SpaceWallPermissionResponse moveSpaceWallPermission(Long id, Long parentId) {
+    public SpaceWallPermissionResponse moveSpaceWallPermission(Long id, Long targetSequence) {
+        SpaceWall currentSpaceWall = spaceWallRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 공유페이스 ID입니다."));
+
+        if (targetSequence == null || targetSequence < 1 || targetSequence > spaceWallRepository.count()) {
+            throw new InvalidTargetSequenceException("잘못된 타겟 순서입니다. 입력 값: " + targetSequence);
+        }
+
+        int currentSequence = currentSpaceWall.getSequence();
+        int targetSeqInt = targetSequence.intValue();
+
+        if (targetSeqInt > currentSequence) {
+            List<SpaceWall> affectedSpaceWalls = spaceWallRepository.findBySequenceBetween(currentSequence + 1, targetSeqInt);
+            for (SpaceWall spaceWall : affectedSpaceWalls) {
+                spaceWall.setSequence(spaceWall.getSequence() - 1);
+                spaceWallRepository.save(spaceWall);
+            }
+        } else if (targetSeqInt < currentSequence) {
+            List<SpaceWall> affectedSpaceWalls = spaceWallRepository.findBySequenceBetween(targetSeqInt, currentSequence - 1);
+            for (SpaceWall spaceWall : affectedSpaceWalls) {
+                spaceWall.setSequence(spaceWall.getSequence() + 1);
+                spaceWallRepository.save(spaceWall);
+            }
+        } else {
+            // Same position, no movement
+            throw new IllegalArgumentException("이동할 필요가 없습니다.");
+        }
+
+        currentSpaceWall.setSequence(targetSeqInt);
+        spaceWallRepository.save(currentSpaceWall);
+
         SpaceWallPermission spaceWallPermission = spaceWallPermissionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 공유페이스 권한 ID입니다."));
 
-        // 상위 ID가 있는 경우 권한이 상속되는지 확인하세요.
-        if (parentId != null) {
-            SpaceWallPermission parentPermission = spaceWallPermissionRepository.findById(parentId)
-                    .orElseThrow(() -> new IllegalArgumentException("잘못된 상위 공유페이스 권한 ID입니다."));
-
-            // 권한은 부모로부터 상속됩니다.
-            spaceWallPermission.setAuths(parentPermission.getAuths());
-        }
-
-        spaceWallPermission.setParentId(parentId);
-        SpaceWallPermission updatedPermission = spaceWallPermissionRepository.save(spaceWallPermission);
-        return new SpaceWallPermissionResponse(updatedPermission);
+        return new SpaceWallPermissionResponse(spaceWallPermission);
     }
+
 
     @Transactional
     public void assignPermissionToSpaceWall(Auths auth, SpaceWall spaceWall) {

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/service/SpaceWallPermissionService.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/service/SpaceWallPermissionService.java
@@ -22,9 +22,9 @@ public class SpaceWallPermissionService {
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 공유페이스 권한 ID입니다."));
 
         spaceWallPermission.setAuths(requestDto.getAuths());
-//        spaceWallPermission.setType(requestDto.getType());
 
-        return new SpaceWallPermissionResponse(spaceWallPermission);
+        SpaceWallPermission updatedPermission = spaceWallPermissionRepository.save(spaceWallPermission);
+        return new SpaceWallPermissionResponse(updatedPermission);
     }
 
     @Transactional
@@ -32,31 +32,25 @@ public class SpaceWallPermissionService {
         SpaceWallPermission spaceWallPermission = spaceWallPermissionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 공유페이스 권한 ID입니다."));
 
-        // 권한 검사
+        // 상위 ID가 있는 경우 권한이 상속되는지 확인하세요.
         if (parentId != null) {
             SpaceWallPermission parentPermission = spaceWallPermissionRepository.findById(parentId)
                     .orElseThrow(() -> new IllegalArgumentException("잘못된 상위 공유페이스 권한 ID입니다."));
 
-//            if (parentPermission.getType() == Type.BLACK) {
-//                throw new IllegalArgumentException("목록 페이지로 이동할 수 없습니다..");
-//            }
+            // 권한은 부모로부터 상속됩니다.
+            spaceWallPermission.setAuths(parentPermission.getAuths());
         }
 
         spaceWallPermission.setParentId(parentId);
-
-        return new SpaceWallPermissionResponse(spaceWallPermission);
+        SpaceWallPermission updatedPermission = spaceWallPermissionRepository.save(spaceWallPermission);
+        return new SpaceWallPermissionResponse(updatedPermission);
     }
 
     @Transactional
     public void assignPermissionToSpaceWall(Auths auth, SpaceWall spaceWall) {
         SpaceWallPermission permission = new SpaceWallPermission();
-//        permission.setSpaceWall(spaceWall);
         permission.setAuths(auth);
         spaceWallPermissionRepository.save(permission);
     }
 
-//    public SpaceWallPermission getPermissionForSpaceWall(SpaceWall spaceWall) {
-//        return spaceWallPermissionRepository.findBySpaceWall(spaceWall)
-//                .orElseThrow(() -> new IllegalArgumentException("해당 공유 스페이스에 대한 권한 정보를 찾을 수 없습니다."));
-//    }
 }

--- a/src/main/java/com/fastcampus/jober/global/error/exception/InvalidTargetSequenceException.java
+++ b/src/main/java/com/fastcampus/jober/global/error/exception/InvalidTargetSequenceException.java
@@ -1,0 +1,7 @@
+package com.fastcampus.jober.global.error.exception;
+
+public class InvalidTargetSequenceException extends RuntimeException {
+    public InvalidTargetSequenceException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
[#4]

- 권한 업데이트 (PUT: /spaces/{id}/authority)
spaceWallId: 해당 ID의 공유 스페이스를 대상으로 권한을 업데이트 합니다.
memberId: 이 회원 ID를 가진 사용자에게 적용될 권한을 업데이트 합니다.
auths: 회원에게 적용될 권한을 나타냅니다.
{
    "spaceWallId": 1,
    "memberId": 1,
    "auths": "OWNER",
    "parentId": 1
}
- 공유페이지의 위치를 이동(PUT: /spaces/{id}/move)
id : 이동하려는 공유 스페이스의 ID입니다.
targetSequence : 공유 스페이스가 이동하려는 목적지의 순서입니다.
{
    "targetSequence": 3
}

첫 번째 요청은 특정 회원의 공유 스페이스에 대한 권한을 업데이트 합니다.
두 번째 요청은 특정 공유 스페이스의 위치를 이동시킵니다.
