### PR TITLE
최근 템플릿 조회, 히스토리 저장 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/jober/domain/template/controller/TemplateController.java
+++ b/src/main/java/com/fastcampus/jober/domain/template/controller/TemplateController.java
@@ -23,13 +23,14 @@ public class TemplateController {
     private final TemplateService templateService;
 
     @GetMapping
-    public ResponseEntity<?> templateList(
+    public ResponseEntity<?> templateList(@AuthenticationPrincipal MemberDetails memberDetails,
         @RequestParam(required = false) String type,
         @RequestParam(required = false) String keyword,
         @RequestParam(required = false, defaultValue = "0") int page) {
         page = page == 0 ? 0 : page - 1;
 
-        Page<ListDto> templates = templateService.findTemplates(type, keyword, page, 10);
+        Page<ListDto> templates = templateService.findTemplates(memberDetails.getMember(), type,
+            keyword, page, 10);
 
         return ResponseEntity.ok(
             ApiUtil.result(HttpStatus.OK.value(), "정상적으로 처리되었습니다.", templates));

--- a/src/main/java/com/fastcampus/jober/domain/template/domain/TemplateUsedHistory.java
+++ b/src/main/java/com/fastcampus/jober/domain/template/domain/TemplateUsedHistory.java
@@ -1,32 +1,44 @@
 package com.fastcampus.jober.domain.template.domain;
 
-import com.fastcampus.jober.domain.BaseTimeEntity;
 import com.fastcampus.jober.domain.member.domain.Member;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
-public class TemplateUsedHistory extends BaseTimeEntity {
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class TemplateUsedHistory {
 
     @Id
-    @Column(nullable = false, unique = true)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @ManyToOne
-    @JoinColumn(name = "template_id")
-    private Template template;
 
     @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
 
-    private LocalDateTime used_at;
+    @ManyToOne
+    @JoinColumn(name = "template_id")
+    private Template template;
 
+    @CreationTimestamp
+    private LocalDateTime usedAt;
+
+    public void updateUsedAt() {
+        this.usedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/fastcampus/jober/domain/template/repository/TemplateUsedHistoryRepository.java
+++ b/src/main/java/com/fastcampus/jober/domain/template/repository/TemplateUsedHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.fastcampus.jober.domain.template.repository;
+
+import com.fastcampus.jober.domain.member.domain.Member;
+import com.fastcampus.jober.domain.template.domain.Template;
+import com.fastcampus.jober.domain.template.domain.TemplateUsedHistory;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemplateUsedHistoryRepository extends JpaRepository<TemplateUsedHistory, Long> {
+
+    Optional<TemplateUsedHistory> findByMemberAndTemplate(Member member, Template template);
+}

--- a/src/main/java/com/fastcampus/jober/domain/template/repository/TemplateUsedHistoryRepository.java
+++ b/src/main/java/com/fastcampus/jober/domain/template/repository/TemplateUsedHistoryRepository.java
@@ -4,9 +4,15 @@ import com.fastcampus.jober.domain.member.domain.Member;
 import com.fastcampus.jober.domain.template.domain.Template;
 import com.fastcampus.jober.domain.template.domain.TemplateUsedHistory;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TemplateUsedHistoryRepository extends JpaRepository<TemplateUsedHistory, Long> {
 
     Optional<TemplateUsedHistory> findByMemberAndTemplate(Member member, Template template);
+
+    @Query("SELECT t.template FROM TemplateUsedHistory t WHERE t.member = :member ORDER BY t.usedAt DESC")
+    Page<Template> findAllByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/fastcampus/jober/domain/template/service/TemplateService.java
+++ b/src/main/java/com/fastcampus/jober/domain/template/service/TemplateService.java
@@ -7,17 +7,17 @@ import com.fastcampus.jober.domain.template.dto.TemplateResponseDto.ListDto;
 import com.fastcampus.jober.domain.template.repository.MyTemplateRepository;
 import com.fastcampus.jober.domain.template.repository.TemplateRepository;
 import com.fastcampus.jober.domain.template.repository.TemplateTypeRepository;
+import com.fastcampus.jober.domain.template.repository.TemplateUsedHistoryRepository;
 import com.fastcampus.jober.global.constant.ErrorCode;
 import com.fastcampus.jober.global.constant.TemplateCategory;
 import com.fastcampus.jober.global.error.exception.TemplateException;
 import io.micrometer.common.util.StringUtils;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,15 +26,18 @@ public class TemplateService {
     private final TemplateRepository templateRepository;
     private final TemplateTypeRepository templateTypeRepository;
     private final MyTemplateRepository myTemplateRepository;
+    private final TemplateUsedHistoryRepository historyRepository;
 
-    public Page<ListDto> findTemplates(String type, String keyword, int page, int size) {
+    @Transactional(readOnly = true)
+    public Page<ListDto> findTemplates(Member member, String type, String keyword, int page,
+        int size) {
         if (page < 0) {
             throw new TemplateException(ErrorCode.PAGE_BAD_REQUEST);
         }
 
         Pageable pageable = PageRequest.of(page, size);
 
-        Page<Template> templatePage = findTemplatePage(type, keyword, pageable);
+        Page<Template> templatePage = findTemplatePage(member, type, keyword, pageable);
 
         Page<ListDto> listDtos = templatePage.map(m -> ListDto.builder()
             .id(m.getId())
@@ -47,19 +50,18 @@ public class TemplateService {
         return listDtos;
     }
 
+    @Transactional
     public void addTemplate(Member member, Long templateId) {
         Template template = templateRepository.findById(templateId)
             .orElseThrow(() -> new TemplateException(ErrorCode.TEMPLATE_NOT_FOUND));
 
-        List<Template> templates = new ArrayList<>();
-        templates.add(template);
-
-        MyTemplate myTemplate = MyTemplate.builder().member(member).templates(templates).build();
+        MyTemplate myTemplate = MyTemplate.builder().member(member).template(template).build();
 
         myTemplateRepository.save(myTemplate);
     }
 
-    private Page<Template> findTemplatePage(String type, String keyword, Pageable pageable) {
+    private Page<Template> findTemplatePage(Member member, String type, String keyword,
+        Pageable pageable) {
 
         if (StringUtils.isBlank(type) && StringUtils.isBlank(keyword)) {
             return templateRepository.findAll(pageable);
@@ -69,7 +71,12 @@ public class TemplateService {
             return templateRepository.findAllByKeywordContains(keyword, pageable);
         }
 
+        //@TODO: 컨트롤러 단에서 처리하기
         TemplateCategory templateCategory = TemplateCategory.findByName(type);
+
+        if (templateCategory == TemplateCategory.RECENT) {
+            return historyRepository.findAllByMember(member, pageable);
+        }
 
         if (!StringUtils.isBlank(type) && StringUtils.isBlank(keyword)) {
             return templateTypeRepository.findByTemplateCategory(templateCategory, pageable);

--- a/src/main/java/com/fastcampus/jober/domain/template/service/TemplateUsedHistoryService.java
+++ b/src/main/java/com/fastcampus/jober/domain/template/service/TemplateUsedHistoryService.java
@@ -1,0 +1,53 @@
+package com.fastcampus.jober.domain.template.service;
+
+import com.fastcampus.jober.domain.member.domain.Member;
+import com.fastcampus.jober.domain.member.repository.MemberRepository;
+import com.fastcampus.jober.domain.template.domain.Template;
+import com.fastcampus.jober.domain.template.domain.TemplateUsedHistory;
+import com.fastcampus.jober.domain.template.repository.TemplateRepository;
+import com.fastcampus.jober.domain.template.repository.TemplateUsedHistoryRepository;
+import com.fastcampus.jober.global.constant.ErrorCode;
+import com.fastcampus.jober.global.error.exception.MemberException;
+import com.fastcampus.jober.global.error.exception.TemplateException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TemplateUsedHistoryService {
+
+    private final TemplateUsedHistoryRepository historyRepository;
+    private final MemberRepository memberRepository;
+    private final TemplateRepository templateRepository;
+
+    @Transactional
+    public void saveHistory(String email, Long templateId) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new MemberException(
+            ErrorCode.MEMBER_NOT_FOUND));
+
+        Template template = templateRepository.findById(templateId)
+            .orElseThrow(() -> new TemplateException(ErrorCode.TEMPLATE_NOT_FOUND));
+
+        TemplateUsedHistory oldHistory = findHistory(member, template);
+
+        if (oldHistory != null) {
+            oldHistory.updateUsedAt();
+            return;
+        }
+
+        TemplateUsedHistory history = TemplateUsedHistory.builder()
+            .member(member)
+            .template(template)
+            .build();
+
+        historyRepository.save(history);
+    }
+
+    private TemplateUsedHistory findHistory(Member member, Template template) {
+        TemplateUsedHistory history = historyRepository.findByMemberAndTemplate(member, template)
+            .orElse(null);
+
+        return history;
+    }
+}


### PR DESCRIPTION
#17 

템플릿 모음 조회 API에서 타입이 최근일 때, 해당 기능 동작하도록함

최근 사용 템플릿 히스토리를 어느 시점에 쌓을건지 결정 후 해당 시점 API에 저장 메서드 적용 필요

### 추후 성능 개선
- Redis의 큐 자료구조 활용해보면 좋을 것 같음