### PR TITLE
동시 편집 접근 제한 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
     //DB
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
+
+    //Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/fastcampus/jober/JoberApplication.java
+++ b/src/main/java/com/fastcampus/jober/JoberApplication.java
@@ -2,10 +2,13 @@ package com.fastcampus.jober;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableRedisHttpSession
 @EnableJpaAuditing
-@SpringBootApplication
+@SpringBootApplication(exclude = {RedisRepositoriesAutoConfiguration.class})
 public class JoberApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallResponse.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallResponse.java
@@ -2,12 +2,11 @@ package com.fastcampus.jober.domain.spacewall.dto;
 
 import com.fastcampus.jober.domain.member.domain.Member;
 import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 public class SpaceWallResponse {
 
@@ -16,6 +15,7 @@ public class SpaceWallResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ResponseDto {
+
         private Long id;
         private Long create_member_id;
         private String url;
@@ -49,17 +49,25 @@ public class SpaceWallResponse {
             Member member = Member.builder().id(create_member_id).build();
 
             return SpaceWall.builder()
-                    .id(id)
-                    .url(url)
-                    .title(title)
-                    .description(description)
-                    .profileImageUrl(profile_image_url)
-                    .backgroundImageUrl(background_image_url)
-                    .pathIds(path_ids)
-                    .shareUrl(share_url)
-                    .shareExpiredAt(share_expired_at)
-                    .sequence(sequence)
-                    .build();
+                .id(id)
+                .url(url)
+                .title(title)
+                .description(description)
+                .profileImageUrl(profile_image_url)
+                .backgroundImageUrl(background_image_url)
+                .pathIds(path_ids)
+                .shareUrl(share_url)
+                .shareExpiredAt(share_expired_at)
+                .sequence(sequence)
+                .build();
         }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SessionDTO {
+
+        private boolean accessable;
     }
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/service/SpaceWallService.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/service/SpaceWallService.java
@@ -3,20 +3,22 @@ package com.fastcampus.jober.domain.spacewall.service;
 import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
 import com.fastcampus.jober.domain.spacewall.dto.SpaceWallRequest;
 import com.fastcampus.jober.domain.spacewall.dto.SpaceWallResponse;
+import com.fastcampus.jober.domain.spacewall.dto.SpaceWallResponse.SessionDTO;
 import com.fastcampus.jober.domain.spacewall.repository.SpaceWallRepository;
 import com.fastcampus.jober.global.error.exception.SpaceWallBadRequestException;
 import com.fastcampus.jober.global.error.exception.SpaceWallNotFoundException;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class SpaceWallService {
 
     private final SpaceWallRepository spaceWallRepository;
+    private final StringRedisTemplate redisTemplate;
 
     @Transactional
     public SpaceWallResponse.ResponseDto create(SpaceWallRequest.CreateDto createDto) {
@@ -36,21 +38,24 @@ public class SpaceWallService {
         }
 
         SpaceWall spaceWall = spaceWallRepository.findById(id)
-                .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다: " + id));
+            .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다: " + id));
         return new SpaceWallResponse.ResponseDto(spaceWall);
     }
 
     @Transactional
-    public SpaceWallResponse.ResponseDto update(Long id, SpaceWallRequest.UpdateDto updateDto) {
+    public SpaceWallResponse.ResponseDto update(Long id, SpaceWallRequest.UpdateDto updateDto,
+        HttpSession httpSession) {
         if (id == null || updateDto == null) {
             throw new SpaceWallBadRequestException("업데이트할 매개 변수가 잘못되었습니다.");
         }
 
         SpaceWall spaceWall = spaceWallRepository.findById(id)
-                .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다: " + id));
+            .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다: " + id));
 
         SpaceWall updatedSpaceWall = updateDto.toEntity();
         spaceWall.update(updatedSpaceWall);
+
+        removeEditSession(id, httpSession);
 
         return new SpaceWallResponse.ResponseDto(spaceWall);
     }
@@ -62,8 +67,40 @@ public class SpaceWallService {
         }
 
         SpaceWall spaceWall = spaceWallRepository.findById(id)
-                .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다.: " + id));
+            .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다.: " + id));
 
         spaceWallRepository.delete(spaceWall);
+    }
+
+    public SpaceWallResponse.SessionDTO checkEditSession(Long memberId, Long spaceWallId,
+        HttpSession httpSession) {
+        boolean accessable = isNotExistSession(spaceWallId, httpSession);
+
+        if (accessable) {
+            addEditSession(memberId, spaceWallId, httpSession);
+        }
+
+        SessionDTO sessionDTO = new SessionDTO(accessable);
+
+        return sessionDTO;
+    }
+
+    private boolean isNotExistSession(Long spaceWallId, HttpSession httpSession) {
+        Long memberId = (Long) httpSession.getAttribute("spaces/" + spaceWallId);
+
+        if (memberId == null) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private void addEditSession(Long memberId, Long spaceWallId, HttpSession httpSession) {
+        httpSession.setAttribute("spaces/" + spaceWallId, memberId);
+        httpSession.setMaxInactiveInterval(13);
+    }
+
+    private void removeEditSession(Long spaceWallId, HttpSession httpSession) {
+        httpSession.removeAttribute("spaces/" + spaceWallId);
     }
 }

--- a/src/main/java/com/fastcampus/jober/global/config/RedisConfig.java
+++ b/src/main/java/com/fastcampus/jober/global/config/RedisConfig.java
@@ -1,0 +1,45 @@
+package com.fastcampus.jober.global.config;
+
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@NoArgsConstructor
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String hostname;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(hostname);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate redisTemplate = new StringRedisTemplate();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}


### PR DESCRIPTION
#45 
- **redis 의존성 추가**
- **POST /spaces/{id}/check** API 생성.
- 편집 페이지 진입 시, 해당 API 호출하여 해당 페이지 세션 여부 체크
- 세션이 없다면 세션 생성 및 응답 바디에 **accessable : true** 응답
- 세션 만료 시간 : **13초 (실제로 프론트엔드 쪽에서 상시저장 호출하는 인터벌에 맞게 변경예정)**
- 공유스페이스 수정 API 호출 시, 세션 제거하도록 기능 추가
- **임시 저장 시, 세션 갱신 여부 테스트 해봐야함**