### PR TITLE
공유스페이스, 권한 API 로그인권한 검증 수정

### DIFF
--- a/src/main/java/com/fastcampus/jober/domain/spacewall/controller/SpaceWallController.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/controller/SpaceWallController.java
@@ -35,27 +35,30 @@ public class SpaceWallController {
             @PathVariable Long id) {
         SpaceWallResponse.ResponseDto foundSpaceWallDto = spaceWallService.findById(id);
 
-//        SpaceWallPermission permission = permissionService.getPermissionForSpaceWall(foundSpaceWallDto.toEntity());
-//        if (permission == null || (permission.getAuths() != Auths.VIEWER && permission.getAuths() != Auths.EDITOR && permission.getAuths() != Auths.OWNER)) {
-//            throw new Exception403(ErrorCode.INVALID_ACCESS.getMessage());
-//        }
-
         return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "완료되었습니다.", foundSpaceWallDto));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<ResponseDTO<SpaceWallResponse.ResponseDto>> updateSpaceWall(
-            @PathVariable Long id, @RequestBody SpaceWallRequest.UpdateDto updateDto,
+            @PathVariable Long id,
+            @RequestBody SpaceWallRequest.UpdateDto updateDto,
+            @AuthenticationPrincipal MemberDetails memberDetails,
             HttpSession httpSession) {
-        SpaceWallResponse.ResponseDto updatedSpaceWallDto = spaceWallService.update(id, updateDto,
-                httpSession);
+
+        SpaceWallResponse.ResponseDto updatedSpaceWallDto = spaceWallService.update(id, updateDto, memberDetails, httpSession);
+
         return new ResponseEntity<>(
                 new ResponseDTO<>(HttpStatus.OK, "수정되었습니다.", updatedSpaceWallDto), HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ResponseDTO<String>> deleteSpaceWall(@PathVariable Long id) {
-        spaceWallService.delete(id);
+    public ResponseEntity<ResponseDTO<String>> deleteSpaceWall(
+            @PathVariable Long id,
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            HttpSession httpSession) {
+
+        spaceWallService.delete(id, memberDetails, httpSession);
+
         return new ResponseEntity<>(
                 new ResponseDTO<>(HttpStatus.OK, "공유페이지 " + id + " 삭제되었습니다.", "Success"),
                 HttpStatus.OK);

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/domain/SpaceWall.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/domain/SpaceWall.java
@@ -7,8 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @AllArgsConstructor
@@ -43,11 +41,8 @@ public class SpaceWall extends BaseTimeEntity {
     @Column(name = "path_ids", length = 100)
     private String pathIds;
 
-    @Column(name = "share_url", length = 100)
-    private String shareUrl;
-
-    @Column(name = "share_expired_at")
-    private LocalDateTime shareExpiredAt;
+    @Column(nullable = false)
+    private boolean authorized;
 
     @Column(nullable = false)
     private int sequence;
@@ -63,11 +58,10 @@ public class SpaceWall extends BaseTimeEntity {
         if (updatedSpaceWall.getProfileImageUrl() != null) this.profileImageUrl = updatedSpaceWall.getProfileImageUrl();
         if (updatedSpaceWall.getBackgroundImageUrl() != null) this.backgroundImageUrl = updatedSpaceWall.getBackgroundImageUrl();
         if (updatedSpaceWall.getPathIds() != null) this.pathIds = updatedSpaceWall.getPathIds();
-        if (updatedSpaceWall.getShareUrl() != null) this.shareUrl = updatedSpaceWall.getShareUrl();
-        if (updatedSpaceWall.getShareExpiredAt() != null) this.shareExpiredAt = updatedSpaceWall.getShareExpiredAt();
+        this.authorized = updatedSpaceWall.isAuthorized();
     }
+
     public void setSequence(int sequence) {
         this.sequence = sequence;
     }
-
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallRequest.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallRequest.java
@@ -4,10 +4,6 @@ import com.fastcampus.jober.domain.member.domain.Member;
 import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
 import lombok.*;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
-
 public class SpaceWallRequest {
 
     @Getter
@@ -21,13 +17,10 @@ public class SpaceWallRequest {
         private String profileImageUrl;
         private String backgroundImageUrl;
         private String pathIds;
-        private String shareUrl;
-        private Date shareExpiredAt;
+        private boolean authorized;
         private Integer sequence;
 
         public SpaceWall toEntityWithMember(Member member) {
-            LocalDateTime shareExpiration = convertDateToLocalDateTime(shareExpiredAt);
-
             return SpaceWall.builder()
                     .createMember(member)
                     .url(url)
@@ -36,14 +29,9 @@ public class SpaceWallRequest {
                     .profileImageUrl(profileImageUrl)
                     .backgroundImageUrl(backgroundImageUrl)
                     .pathIds(pathIds)
-                    .shareUrl(shareUrl)
-                    .shareExpiredAt(shareExpiration)
+                    .authorized(authorized)
                     .sequence(sequence != null ? sequence : 0)
                     .build();
-        }
-
-        private LocalDateTime convertDateToLocalDateTime(Date date) {
-            return (date != null) ? LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()) : null;
         }
     }
 
@@ -57,12 +45,9 @@ public class SpaceWallRequest {
         private String profileImageUrl;
         private String backgroundImageUrl;
         private String pathIds;
-        private String shareUrl;
-        private Date shareExpiredAt;
+        private boolean authorized;
 
         public SpaceWall toEntity() {
-            LocalDateTime shareExpiration = convertDateToLocalDateTime(shareExpiredAt);
-
             return SpaceWall.builder()
                     .url(url)
                     .title(title)
@@ -70,13 +55,8 @@ public class SpaceWallRequest {
                     .profileImageUrl(profileImageUrl)
                     .backgroundImageUrl(backgroundImageUrl)
                     .pathIds(pathIds)
-                    .shareUrl(shareUrl)
-                    .shareExpiredAt(shareExpiration)
+                    .authorized(authorized)
                     .build();
-        }
-
-        private LocalDateTime convertDateToLocalDateTime(Date date) {
-            return (date != null) ? LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()) : null;
         }
     }
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallResponse.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/dto/SpaceWallResponse.java
@@ -2,11 +2,9 @@ package com.fastcampus.jober.domain.spacewall.dto;
 
 import com.fastcampus.jober.domain.member.domain.Member;
 import com.fastcampus.jober.domain.spacewall.domain.SpaceWall;
+import lombok.*;
+
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class SpaceWallResponse {
 
@@ -15,7 +13,6 @@ public class SpaceWallResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ResponseDto {
-
         private Long id;
         private Long create_member_id;
         private String url;
@@ -24,8 +21,7 @@ public class SpaceWallResponse {
         private String profile_image_url;
         private String background_image_url;
         private String path_ids;
-        private String share_url;
-        private LocalDateTime share_expired_at;
+        private boolean authorized;
         private LocalDateTime created_at;
         private LocalDateTime updated_at;
         private int sequence;
@@ -39,8 +35,7 @@ public class SpaceWallResponse {
             this.profile_image_url = spaceWall.getProfileImageUrl();
             this.background_image_url = spaceWall.getBackgroundImageUrl();
             this.path_ids = spaceWall.getPathIds();
-            this.share_url = spaceWall.getShareUrl();
-            this.share_expired_at = spaceWall.getShareExpiredAt();
+            this.authorized = spaceWall.isAuthorized();
             this.created_at = spaceWall.getCreatedAt();
             this.updated_at = spaceWall.getUpdatedAt();
             this.sequence = spaceWall.getSequence();
@@ -50,17 +45,16 @@ public class SpaceWallResponse {
             Member member = Member.builder().id(create_member_id).build();
 
             return SpaceWall.builder()
-                .id(id)
-                .url(url)
-                .title(title)
-                .description(description)
-                .profileImageUrl(profile_image_url)
-                .backgroundImageUrl(background_image_url)
-                .pathIds(path_ids)
-                .shareUrl(share_url)
-                .shareExpiredAt(share_expired_at)
-                .sequence(sequence)
-                .build();
+                    .id(id)
+                    .url(url)
+                    .title(title)
+                    .description(description)
+                    .profileImageUrl(profile_image_url)
+                    .backgroundImageUrl(background_image_url)
+                    .pathIds(path_ids)
+                    .authorized(authorized)
+                    .sequence(sequence)
+                    .build();
         }
     }
 
@@ -68,7 +62,6 @@ public class SpaceWallResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SessionDTO {
-
         private boolean accessable;
     }
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/service/SpaceWallService.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/service/SpaceWallService.java
@@ -60,7 +60,6 @@ public class SpaceWallService {
         SpaceWall spaceWall = spaceWallRepository.findById(id)
                 .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다: " + id));
 
-        // 로그인한 사용자와 SpaceWall의 생성자를 비교하여 권한 검사
         if (!spaceWall.getCreateMember().getId().equals(memberDetails.getMember().getId())) {
             throw new SpaceWallBadRequestException("수정 권한이 없습니다.");
         }
@@ -68,7 +67,6 @@ public class SpaceWallService {
         SpaceWall updatedSpaceWall = updateDto.toEntity();
         spaceWall.update(updatedSpaceWall);
 
-        // 수정 후 세션에서 편집 상태 제거
         removeEditSession(id, httpSession);
 
         return new SpaceWallResponse.ResponseDto(spaceWall);
@@ -83,12 +81,10 @@ public class SpaceWallService {
         SpaceWall spaceWall = spaceWallRepository.findById(id)
                 .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다.: " + id));
 
-        // 로그인한 사용자와 SpaceWall의 생성자를 비교하여 권한 검사
         if (!spaceWall.getCreateMember().getId().equals(memberDetails.getMember().getId())) {
             throw new SpaceWallBadRequestException("삭제 권한이 없습니다.");
         }
 
-        // 삭제 전 세션에서 편집 상태 제거
         removeEditSession(id, httpSession);
 
         if ("1".equals(spaceWall.getPathIds())) {

--- a/src/main/java/com/fastcampus/jober/domain/spacewall/service/SpaceWallService.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewall/service/SpaceWallService.java
@@ -52,7 +52,7 @@ public class SpaceWallService {
 
     @Transactional
     public SpaceWallResponse.ResponseDto update(Long id, SpaceWallRequest.UpdateDto updateDto,
-                                                HttpSession httpSession) {
+                                                MemberDetails memberDetails, HttpSession httpSession) {
         if (id == null || updateDto == null) {
             throw new SpaceWallBadRequestException("업데이트할 매개 변수가 잘못되었습니다.");
         }
@@ -60,22 +60,36 @@ public class SpaceWallService {
         SpaceWall spaceWall = spaceWallRepository.findById(id)
                 .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다: " + id));
 
+        // 로그인한 사용자와 SpaceWall의 생성자를 비교하여 권한 검사
+        if (!spaceWall.getCreateMember().getId().equals(memberDetails.getMember().getId())) {
+            throw new SpaceWallBadRequestException("수정 권한이 없습니다.");
+        }
+
         SpaceWall updatedSpaceWall = updateDto.toEntity();
         spaceWall.update(updatedSpaceWall);
 
+        // 수정 후 세션에서 편집 상태 제거
         removeEditSession(id, httpSession);
 
         return new SpaceWallResponse.ResponseDto(spaceWall);
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void delete(Long id, MemberDetails memberDetails, HttpSession httpSession) {
         if (id == null) {
             throw new SpaceWallBadRequestException("공유페이지 ID는 null일 수 없습니다.");
         }
 
         SpaceWall spaceWall = spaceWallRepository.findById(id)
                 .orElseThrow(() -> new SpaceWallNotFoundException("ID가 있는 공유페이지을 찾을 수 없습니다.: " + id));
+
+        // 로그인한 사용자와 SpaceWall의 생성자를 비교하여 권한 검사
+        if (!spaceWall.getCreateMember().getId().equals(memberDetails.getMember().getId())) {
+            throw new SpaceWallBadRequestException("삭제 권한이 없습니다.");
+        }
+
+        // 삭제 전 세션에서 편집 상태 제거
+        removeEditSession(id, httpSession);
 
         if ("1".equals(spaceWall.getPathIds())) {
             throw new SpaceWallBadRequestException("최상단의 공유페이지는 삭제할 수 없습니다.");

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/controller/SpaceWallPermissionController.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/controller/SpaceWallPermissionController.java
@@ -3,10 +3,12 @@ package com.fastcampus.jober.domain.spacewallpermission.controller;
 import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionRequest;
 import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionResponse;
 import com.fastcampus.jober.domain.spacewallpermission.service.SpaceWallPermissionService;
+import com.fastcampus.jober.global.auth.session.MemberDetails;
 import com.fastcampus.jober.global.utils.api.dto.ResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,14 +19,22 @@ public class SpaceWallPermissionController {
     private final SpaceWallPermissionService spaceWallPermissionService;
 
     @PutMapping("/{id}/authority")
-    public ResponseEntity<ResponseDTO<SpaceWallPermissionResponse>> updatePermission(@PathVariable Long id, @RequestBody SpaceWallPermissionRequest requestDto) {
-        SpaceWallPermissionResponse response = spaceWallPermissionService.updatePermission(id, requestDto);
+    public ResponseEntity<ResponseDTO<SpaceWallPermissionResponse>> updatePermission(
+            @PathVariable Long id,
+            @RequestBody SpaceWallPermissionRequest requestDto,
+            @AuthenticationPrincipal MemberDetails memberDetails) {
+
+        SpaceWallPermissionResponse response = spaceWallPermissionService.updatePermission(id, requestDto, memberDetails);
         return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "권한을 수정하였습니다.", response));
     }
 
     @PutMapping("/{id}/move")
-    public ResponseEntity<ResponseDTO<SpaceWallPermissionResponse>> moveSpaceWallPermission(@PathVariable Long id, @RequestBody SpaceWallPermissionRequest requestDto) {
-        SpaceWallPermissionResponse response = spaceWallPermissionService.moveSpaceWallPermission(id, requestDto.getTargetSequence());
+    public ResponseEntity<ResponseDTO<SpaceWallPermissionResponse>> moveSpaceWallPermission(
+            @PathVariable Long id,
+            @RequestBody SpaceWallPermissionRequest requestDto,
+            @AuthenticationPrincipal MemberDetails memberDetails) {
+
+        SpaceWallPermissionResponse response = spaceWallPermissionService.moveSpaceWallPermission(id, requestDto.getTargetSequence(), memberDetails);
         return ResponseEntity.ok(new ResponseDTO<>(HttpStatus.OK, "공유페이지의 위치를 수정하였습니다.", response));
     }
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionRequest.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionRequest.java
@@ -1,7 +1,6 @@
 package com.fastcampus.jober.domain.spacewallpermission.dto;
 
 import com.fastcampus.jober.global.constant.Auths;
-import com.fastcampus.jober.global.constant.Type;
 import lombok.*;
 
 @Getter
@@ -10,8 +9,8 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SpaceWallPermissionRequest {
-    private Long spaceWallId;  // 공유 스페이스 ID
-    private Long memberId;     // 회원 ID
-    private Auths auths;       // READ / EDIT / DELETE
-    private Long targetSequence;    // 상위 페이지 ID
+    private Long spaceWallId;
+    private Long memberId;
+    private Auths auths;
+    private Long targetSequence;
 }

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionResponse.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/dto/SpaceWallPermissionResponse.java
@@ -13,10 +13,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class SpaceWallPermissionResponse {
     private Long id;
-    private Auths auths;       // READ / EDIT / DELETE
+    private Auths auths;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private Long parentId;     // 상위 페이지 ID
+    private Long parentId;
 
     public SpaceWallPermissionResponse(SpaceWallPermission spaceWallPermission) {
         this.id = spaceWallPermission.getId();

--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/service/SpaceWallPermissionService.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/service/SpaceWallPermissionService.java
@@ -6,6 +6,7 @@ import com.fastcampus.jober.domain.spacewallpermission.domain.SpaceWallPermissio
 import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionRequest;
 import com.fastcampus.jober.domain.spacewallpermission.dto.SpaceWallPermissionResponse;
 import com.fastcampus.jober.domain.spacewallpermission.repository.SpaceWallPermissionRepository;
+import com.fastcampus.jober.global.auth.session.MemberDetails;
 import com.fastcampus.jober.global.constant.Auths;
 import com.fastcampus.jober.global.error.exception.InvalidTargetSequenceException;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,11 @@ public class SpaceWallPermissionService {
     private final SpaceWallRepository spaceWallRepository;
 
     @Transactional
-    public SpaceWallPermissionResponse updatePermission(Long id, SpaceWallPermissionRequest requestDto) {
+    public SpaceWallPermissionResponse updatePermission(Long id, SpaceWallPermissionRequest requestDto, MemberDetails memberDetails) {
+        if (memberDetails == null || !memberDetails.getMember().getId().equals(requestDto.getMemberId())) {
+            throw new IllegalArgumentException("접근 권한이 없습니다.");
+        }
+
         SpaceWallPermission spaceWallPermission = spaceWallPermissionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 공유페이스 권한 ID입니다."));
 
@@ -33,7 +38,11 @@ public class SpaceWallPermissionService {
     }
 
     @Transactional
-    public SpaceWallPermissionResponse moveSpaceWallPermission(Long id, Long targetSequence) {
+    public SpaceWallPermissionResponse moveSpaceWallPermission(Long id, Long targetSequence, MemberDetails memberDetails) {
+        if (memberDetails == null) {
+            throw new IllegalArgumentException("접근 권한이 없습니다.");
+        }
+
         SpaceWall currentSpaceWall = spaceWallRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("잘못된 공유페이스 ID입니다."));
 
@@ -57,7 +66,6 @@ public class SpaceWallPermissionService {
                 spaceWallRepository.save(spaceWall);
             }
         } else {
-            // Same position, no movement
             throw new IllegalArgumentException("이동할 필요가 없습니다.");
         }
 
@@ -69,7 +77,6 @@ public class SpaceWallPermissionService {
 
         return new SpaceWallPermissionResponse(spaceWallPermission);
     }
-
 
     @Transactional
     public void assignPermissionToSpaceWall(Auths auth, SpaceWall spaceWall) {

--- a/src/main/resources/db/data-h2.sql
+++ b/src/main/resources/db/data-h2.sql
@@ -3,26 +3,26 @@
 -- 회원가입 시 데이터 생성 플로우 --
 -- 가입 > 워크스페이스 생성(생략) > 공유스페이스 생성 > OWNER 권한으로 공동작업자에 등록 > 공유스페이스 히스토리 생성
 INSERT INTO member (email, password, username, created_at) VALUES ('member1@gmail.com', 'apaqj11!', '멤버1', CURRENT_TIMESTAMP);
-INSERT INTO space_wall (create_member_id, url, title, description, profile_image_url, background_image_url, share_url, share_expired_at, sequence, created_at)
-VALUES (1, 'https://dummy-url-1.com', 'Dummy Title 1', 'Dummy Description 1', 'https://dummy-profile-image-1.com', 'https://dummy-bg-image-1.com', 'https://dummy-share-url-1.com', DATEADD('DAY', 10, CURRENT_TIMESTAMP), 1, CURRENT_TIMESTAMP);
+INSERT INTO space_wall (create_member_id, url, title, description, profile_image_url, background_image_url, path_ids, authorized, sequence, created_at)
+VALUES (1, 'https://dummy-url-1.com', 'Dummy Title 1', 'Dummy Description 1', 'https://dummy-profile-image-1.com', 'https://dummy-bg-image-1.com', '1,2,3', TRUE, 1, CURRENT_TIMESTAMP);
 INSERT INTO space_wall_member (member_id, space_wall_id, created_at) VALUES (1, 1, CURRENT_TIMESTAMP); -- OWNER 1
 INSERT INTO space_wall_permission (space_wall_member_id, auths, created_at) VALUES (1, 'OWNER', CURRENT_TIMESTAMP);
 
 INSERT INTO member (email, password, username, created_at) VALUES ('member2@gmail.com', 'apaqj11!', '멤버2', CURRENT_TIMESTAMP);
-INSERT INTO space_wall (create_member_id, url, title, description, profile_image_url, background_image_url, share_url, share_expired_at, sequence, created_at)
-VALUES (2, 'https://dummy-url-2.com', 'Dummy Title 2', 'Dummy Description 2', 'https://dummy-profile-image-2.com', 'https://dummy-bg-image-2.com', 'https://dummy-share-url-2.com', DATEADD('DAY', 5, CURRENT_TIMESTAMP), 1, CURRENT_TIMESTAMP);
+INSERT INTO space_wall (create_member_id, url, title, description, profile_image_url, background_image_url, path_ids, authorized, sequence, created_at)
+VALUES (2, 'https://dummy-url-2.com', 'Dummy Title 2', 'Dummy Description 2', 'https://dummy-profile-image-2.com', 'https://dummy-bg-image-2.com', '4,5,6', TRUE, 1, CURRENT_TIMESTAMP);
 INSERT INTO space_wall_member (member_id, space_wall_id, created_at) VALUES (2, 2, CURRENT_TIMESTAMP); -- OWNER 1
 INSERT INTO space_wall_permission (space_wall_member_id, auths, created_at) VALUES (2, 'OWNER', CURRENT_TIMESTAMP);
 
 INSERT INTO member (email, password, username, created_at) VALUES ('member3@gmail.com', 'apaqj11!', '멤버3', CURRENT_TIMESTAMP);
-INSERT INTO space_wall (create_member_id, url, title, description, profile_image_url, background_image_url, share_url, share_expired_at, sequence, created_at)
-VALUES (3, 'https://dummy-url-3.com', 'Dummy Title 3', 'Dummy Description 3', 'https://dummy-profile-image-3.com', 'https://dummy-bg-image-3.com', 'https://dummy-share-url-3.com', DATEADD('DAY', 3, CURRENT_TIMESTAMP), 1, CURRENT_TIMESTAMP);
+INSERT INTO space_wall (create_member_id, url, title, description, profile_image_url, background_image_url, path_ids, authorized, sequence, created_at)
+VALUES (3, 'https://dummy-url-3.com', 'Dummy Title 3', 'Dummy Description 3', 'https://dummy-profile-image-3.com', 'https://dummy-bg-image-3.com', '1,2,3,4', TRUE, 1, CURRENT_TIMESTAMP);
 INSERT INTO space_wall_member (member_id, space_wall_id, created_at) VALUES (3, 3, CURRENT_TIMESTAMP); -- OWNER 1
 INSERT INTO space_wall_permission (space_wall_member_id, auths, created_at) VALUES (3, 'OWNER', CURRENT_TIMESTAMP);
 
 INSERT INTO member (email, password, username, created_at) VALUES ('member4@gmail.com', 'apaqj11!', '멤버4', CURRENT_TIMESTAMP);
-INSERT INTO space_wall (create_member_id, url, title, description, profile_image_url, background_image_url, share_url, share_expired_at, sequence, created_at)
-VALUES (4, 'https://dummy-url-4.com', 'Dummy Title 4', 'Dummy Description 4', 'https://dummy-profile-image-4.com', 'https://dummy-bg-image-4.com', 'https://dummy-share-url-4.com', DATEADD('DAY', 3, CURRENT_TIMESTAMP), 1, CURRENT_TIMESTAMP);
+INSERT INTO space_wall (create_member_id, url, title, description, profile_image_url, background_image_url, path_ids, authorized, sequence, created_at)
+VALUES (4, 'https://dummy-url-4.com', 'Dummy Title 4', 'Dummy Description 4', 'https://dummy-profile-image-4.com', 'https://dummy-bg-image-4.com', '4,5,6,7', FALSE, 1, CURRENT_TIMESTAMP);
 INSERT INTO space_wall_member (member_id, space_wall_id, created_at) VALUES (4, 4, CURRENT_TIMESTAMP); -- OWNER 1
 INSERT INTO space_wall_permission (space_wall_member_id, auths, created_at) VALUES (4, 'OWNER', CURRENT_TIMESTAMP);
 


### PR DESCRIPTION
[#4]

- 현재 만든 API 로그인 토큰 기반으로 권한 설정 수정 완료
- share_url, share_expired_at 삭제 -> authorized boolean 타입 추가
- db도 맞게 수정 완료
생성 바디 수정
{
    "createMember": 1,
    "url": "https://example.com/spacewa5",
    "title": "My SpaceWall Title2",
    "description": "This is the description of my SpaceWall2233.",
    "profileImageUrl": "https://images.example.com/profile2.jpg",
    "backgroundImageUrl": "https://images.example.com/background2.jpg",
    "pathIds": "1,2,3,4",
    "authorized": true,
    "sequence": 1
}