### PR TITLE
RedisConfig 오류 수정

### DIFF
--- a/src/main/java/com/fastcampus/jober/global/config/RedisConfig.java
+++ b/src/main/java/com/fastcampus/jober/global/config/RedisConfig.java
@@ -18,7 +18,7 @@ public class RedisConfig {
     private String hostname;
 
     @Value("${spring.data.redis.port}")
-    private int port;
+    private String port;
 
     @Value("${spring.data.redis.password}")
     private String password;
@@ -27,7 +27,7 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(hostname);
-        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPort(Integer.parseInt(port));
         redisStandaloneConfiguration.setPassword(password);
 
         return new LettuceConnectionFactory(redisStandaloneConfiguration);


### PR DESCRIPTION
- RedisConfig 클래스에 port 필드의 타입을 int로 선언했는데 yml의 값을 string으로 인식해서 오류 발생
- port 필드의 타입을 String으로 바꾸고 셋팅하는 부분에서 Integer.parseInt로 형변환하도록 수정