### PR TITLE
공유스페이스 삭제 로직 수정

### DIFF
--- a/src/main/java/com/fastcampus/jober/domain/spacewallpermission/repository/SpaceWallPermissionRepository.java
+++ b/src/main/java/com/fastcampus/jober/domain/spacewallpermission/repository/SpaceWallPermissionRepository.java
@@ -25,4 +25,6 @@ public interface SpaceWallPermissionRepository extends JpaRepository<SpaceWallPe
 
     @Query("SELECT swp.auths FROM SpaceWallPermission swp WHERE swp.spaceWallMember.id = :spaceWallMemberId")
     Auths selectAuths(@Param("spaceWallMemberId") Long spaceWallMemberId);
+
+    void deleteAllBySpaceWallMemberId(Long spaceWallMemberId);
 }


### PR DESCRIPTION
#4 
공유스페이스 삭제 로직 수정
spaceWallMember에 관련된 모든 데이터를 삭제합니다.
spaceWallPermission에 관련된 모든 데이터를 삭제합니다. 
모든 연관된 데이터가 삭제된 후, 실제 공유페이지를 삭제합니다.