### PR TITLE
공유스페이스 생성 API 권한 체크 오류 수정

### DIFF
--- a/src/main/java/com/fastcampus/jober/global/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/jober/global/config/SecurityConfig.java
@@ -138,7 +138,7 @@ public class SecurityConfig {
             authorize
                 .requestMatchers(
                     new AntPathRequestMatcher("/my-spaces"),
-                    new AntPathRequestMatcher("new-spaces"),
+                    new AntPathRequestMatcher("/new-spaces"),
                     new AntPathRequestMatcher("/check-token"),
                     new AntPathRequestMatcher("/check-email/**"),
                     new AntPathRequestMatcher("/templates/**"),


### PR DESCRIPTION
#106 

- FilterChain에서 requestMatchers에 "new-spaces" -> /를 빼먹음....