### PR TITLE
권한 체크 메서드 분리

### DIFF
--- a/src/main/java/com/fastcampus/jober/global/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/jober/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import static com.fastcampus.jober.global.constant.ErrorCode.INVALID_USER;
 import com.fastcampus.jober.global.auth.jwt.JwtAuthenticationFilter;
 import com.fastcampus.jober.global.auth.jwt.JwtExceptionFilter;
 import com.fastcampus.jober.global.error.exception.TokenException;
+import com.fastcampus.jober.global.security.filter.MyRequestFilter;
 import com.fastcampus.jober.global.security.manager.CustomAuthorizationManager;
 import com.fastcampus.jober.global.utils.FilterResponseUtils;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -34,6 +36,7 @@ public class SecurityConfig {
 
     private final JwtExceptionFilter jwtExceptionFilter;
     private final CustomAuthorizationManager customAuthorizationManager;
+    private final MyRequestFilter requestFilter;
 
 //    @Bean
 //    BCryptPasswordEncoder passwordEncoder() {
@@ -138,7 +141,6 @@ public class SecurityConfig {
             authorize
                 .requestMatchers(
                     new AntPathRequestMatcher("/my-spaces"),
-                    new AntPathRequestMatcher("/new-spaces"),
                     new AntPathRequestMatcher("/check-token"),
                     new AntPathRequestMatcher("/check-email/**"),
                     new AntPathRequestMatcher("/templates/**"),
@@ -150,6 +152,8 @@ public class SecurityConfig {
                 .permitAll()
                 .anyRequest().access(customAuthorizationManager);
         });
+
+        http.addFilterBefore(requestFilter, AuthorizationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/fastcampus/jober/global/security/filter/MyRequestFilter.java
+++ b/src/main/java/com/fastcampus/jober/global/security/filter/MyRequestFilter.java
@@ -1,0 +1,23 @@
+package com.fastcampus.jober.global.security.filter;
+
+import com.fastcampus.jober.global.utils.RequestWrapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class MyRequestFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        RequestWrapper wrapper = new RequestWrapper(request);
+
+        filterChain.doFilter(wrapper, response);
+    }
+}

--- a/src/main/java/com/fastcampus/jober/global/security/manager/CustomAuthorizationManager.java
+++ b/src/main/java/com/fastcampus/jober/global/security/manager/CustomAuthorizationManager.java
@@ -8,8 +8,13 @@ import com.fastcampus.jober.domain.spacewallpermission.repository.SpaceWallPermi
 import com.fastcampus.jober.global.auth.session.MemberDetails;
 import com.fastcampus.jober.global.constant.Auths;
 import com.fastcampus.jober.global.error.exception.SpaceWallNotFoundException;
+import io.micrometer.common.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.function.Supplier;
+import org.apache.tomcat.util.json.JSONParser;
+import org.apache.tomcat.util.json.ParseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authorization.AuthorizationDecision;
@@ -35,32 +40,14 @@ public class CustomAuthorizationManager implements
         RequestAuthorizationContext requestAuthorizationContext) {
         HttpServletRequest request = requestAuthorizationContext.getRequest();
 
-        Long spaceWallId = parseSpaceWallId(request.getRequestURI());
-        SpaceWall spaceWall = spaceWallRepository.findById(spaceWallId)
-            .orElseThrow(() -> new SpaceWallNotFoundException("찾을 수 없습니다."));
-
-        if (request.getRequestURI().contains("/spaces/view") && !spaceWall.isAuthorized()) {
-            return new AuthorizationDecision(true);
-        }
-
         MemberDetails memberDetails = (MemberDetails) authentication.get().getPrincipal();
 
-        SpaceWallMember spaceWallMember = spaceWallMemberRepository.selectSpaceWallMember(
-            spaceWallId, memberDetails.getMemberId());
-
-        if (spaceWallMember == null) {
-            return new AuthorizationDecision(false);
-        }
-
-        Auths auth = permissionRepository.selectAuths(
-            spaceWallMember.getId());
-
-        boolean access = checkSpacesUrlPattern(request, auth);
+        boolean access = checkUrlPattern(request, memberDetails.getMemberId());
 
         return new AuthorizationDecision(access);
     }
 
-    private Long parseSpaceWallId(String requestUri) {
+    private Long parseSpaceWallId(String requestUri) throws NumberFormatException {
         String[] array = requestUri.split("/");
 
         Long spaceWallId = Long.parseLong(array[array.length - 1]);
@@ -68,11 +55,75 @@ public class CustomAuthorizationManager implements
         return spaceWallId;
     }
 
-    private boolean checkSpacesUrlPattern(HttpServletRequest request,
-        Auths auth) {
+    private boolean checkUrlPattern(HttpServletRequest request,
+        Long memberId) {
 
         String uri = request.getRequestURI();
         HttpMethod method = HttpMethod.valueOf(request.getMethod());
+
+        if (uri.contains("/new-spaces")) {
+            return checkNewSpacesUrlPattern(request, memberId);
+        }
+
+        Long spaceWallId = parseSpaceWallId(uri);
+        SpaceWall spaceWall = spaceWallRepository.findById(spaceWallId)
+            .orElseThrow(() -> new SpaceWallNotFoundException("찾을 수 없습니다."));
+
+        if (uri.contains("/spaces/view") && !spaceWall.isAuthorized()) {
+            return true;
+        }
+
+        SpaceWallMember spaceWallMember = spaceWallMemberRepository.selectSpaceWallMember(
+            spaceWallId, memberId);
+
+        if (spaceWallMember == null) {
+            return false;
+        }
+
+        Auths auth = permissionRepository.selectAuths(
+            spaceWallMember.getId());
+
+        if (uri.contains("/spaces")) {
+            return checkSpacesUrlPattern(uri, method, auth);
+        }
+
+        if (uri.contains("Temps")) {
+            return checkTempUrlPattern(uri, method, auth);
+        }
+
+        return false;
+    }
+
+    private boolean checkNewSpacesUrlPattern(HttpServletRequest request, Long memberId) {
+        JSONParser jsonParser = null;
+        try {
+            jsonParser = new JSONParser(request.getInputStream());
+            LinkedHashMap<String, Object> jsonObject = jsonParser.parseObject();
+
+            if (StringUtils.isBlank(jsonObject.get("parentSpaceWallId").toString())) {
+                return true;
+            }
+
+            Long parentSpaceWallId = Long.parseLong(
+                jsonObject.get("parentSpaceWallId").toString());
+
+            SpaceWallMember spaceWallMember = spaceWallMemberRepository.selectSpaceWallMember(
+                parentSpaceWallId, memberId);
+
+            if (spaceWallMember == null) {
+                return false;
+            }
+
+            Auths auth = permissionRepository.selectAuths(
+                spaceWallMember.getId());
+
+            return auth == Auths.EDITOR || auth == Auths.OWNER;
+        } catch (IOException | ParseException e) {
+            return false;
+        }
+    }
+
+    private boolean checkSpacesUrlPattern(String uri, HttpMethod method, Auths auth) {
 
         if (uri.contains("/spaces/member")) {
             return auth == Auths.OWNER;
@@ -93,6 +144,14 @@ public class CustomAuthorizationManager implements
             }
 
             return true;
+        }
+
+        return false;
+    }
+
+    private boolean checkTempUrlPattern(String uri, HttpMethod method, Auths auth) {
+        if (uri.contains("/spaceTemps") || uri.contains("/componentTemps")) {
+            return auth == Auths.EDITOR || auth == Auths.OWNER;
         }
 
         return false;

--- a/src/main/java/com/fastcampus/jober/global/utils/RequestWrapper.java
+++ b/src/main/java/com/fastcampus/jober/global/utils/RequestWrapper.java
@@ -1,0 +1,60 @@
+package com.fastcampus.jober.global.utils;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.springframework.util.StreamUtils;
+
+public class RequestWrapper extends HttpServletRequestWrapper {
+
+    private String requestData;
+
+    public RequestWrapper(HttpServletRequest request) throws IOException {
+        super(request);
+        requestData = requestDataByte(request);
+    }
+
+    private String requestDataByte(HttpServletRequest request) throws IOException {
+        ServletInputStream inputStream = request.getInputStream();
+        byte[] rawData = StreamUtils.copyToByteArray(inputStream);
+        return new String(rawData);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(
+            this.requestData.getBytes(StandardCharsets.UTF_8));
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return inputStream.available() == 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener listener) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int read() {
+                return inputStream.read();
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        return new BufferedReader(new InputStreamReader(this.getInputStream()));
+    }
+}


### PR DESCRIPTION
#102 

- url pattern 별로 메서드 분리함
- request.getInputStream()은 AuthorizationManager에서 읽을 경우, 컨트롤러에서 바디를 못가져오는 불상사가 일어남
- HttpServletRequestWrapper를 구현하여 해당 클래스에 request 값을 담음
- MyRequestFilter에서 해당 request값을 다음 필터로 전달하도록 함
- AuthorizationFilter 동작 전에 MyRequestFilter가 HttpServletRequestWrapper를 전달함