### PR TITLE
querydsl 빌드 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,9 @@ dependencies {
     //querydsl
     implementation 'com.querydsl:querydsl-jpa'
     implementation 'com.querydsl:querydsl-collections'
-    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
     //DB
     runtimeOnly 'com.mysql:mysql-connector-j'


### PR DESCRIPTION
#124 

- querydsl-apt:jpa -> :jakarta로 수정
- jakarta.persistence-api 의존성 추가